### PR TITLE
`Finder` results for the same node are shown together

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ We can show the `href` attribute instead:
 
 Or we can show both the text and the `href`:
 
-    curl https://daringfireball.net | candle 'dl a:not([title]) attr{href}, dl a:not([title]) {text}'
+    curl https://daringfireball.net | candle 'dl a:not([title]) attr{text}, dl a:not([title]) {href}'
 
-    https://techcrunch.com/2019/08/30/someone-hacked-jack-dorseys-own-twitter-account/
-    https://inessential.com/2019/08/26/netnewswire_5_0_now_available
     Jack Dorsey’s Twitter Account Was Compromised
+    https://techcrunch.com/2019/08/30/someone-hacked-jack-dorseys-own-twitter-account/
     NetNewsWire 5.0
+    https://inessential.com/2019/08/26/netnewswire_5_0_now_available
 
 ## Inspiration
 


### PR DESCRIPTION
For example, if the finders are:

* `div attr{class}` and
* `div {text}`

Then previously, it would show all of the `class`es, then all of the `text`s.

Now it will show the information for a given node next to each other. So it will show each div's class, then that same div's text, then the next div's class and text, and so on.